### PR TITLE
Fix OSError when timeout is reached

### DIFF
--- a/inotify_simple/inotify_simple.py
+++ b/inotify_simple/inotify_simple.py
@@ -81,7 +81,10 @@ class INotify(object):
             list: list of :attr:`~inotify_simple.Event` namedtuples"""
         # Wait for the first event:
         pending = self._poller.poll(timeout)
-        if pending and read_delay is not None:
+        if not pending:
+            # Timed out, no events
+            return []
+        elif pending and read_delay is not None:
             # Wait for more events to accumulate:
             time.sleep(read_delay/1000.0)
         # How much data is available to read?


### PR DESCRIPTION
[poll()](https://docs.python.org/3.5/library/select.html#select.poll.poll) return a possibly-empty list.
An empty list indicates that the call timed out and no file descriptors had any events to report.
If there aren't events to read, os.read() will fail.

```
Traceback (most recent call last):
  ...
  File "...", line 100, in ...
    for event in inotify.read(read_delay=30, timeout=2000):
  File ".../lib64/python3.5/site-packages/inotify_simple/inotify_simple.py", line 176, in read
    data = os.read(self.fd, buffer_size)
OSError: [Errno 22] Invalid argument
```
