### PR TITLE
Add pathlib as a requirement for python versions < 3.4 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ or to install from source:
 $ python3 setup.py install
 ```
 
-Note:  If on Python < 3.4, you'll need the backported [enum34
-module](https://pypi.python.org/pypi/enum34).
+Note:
+* If on Python < 3.4, you'll need the backported [enum34
+module](https://pypi.python.org/pypi/enum34)
+and the backported [pathlib module](https://pypi.python.org/pypi/pathlib/).
 
 `inotify_simple` is a small amount of code and unlikely to change much in the
 future until inotify itself or Python changes, so you can also just copy and


### PR DESCRIPTION
I noticed that the latest version of `inotify_simple` breaks support for versions of python < 3.4 due to using the `pathlib` module.

This happened in tests for one of my projects:
https://travis-ci.org/MichaelAquilina/S4/jobs/306531419

An initial step to fixing this is to just specify it as a requirement in the README as you do with `enum34.

You can see my fix here: https://github.com/MichaelAquilina/S4/pull/98

However, it might be a nasty surprise for some others believing their python3 project should be safe if it is tested regularly tested.

@chrisjbillington