### PR TITLE
INotify: Add `fileno()` method

### DIFF
--- a/inotify_simple/inotify_simple.py
+++ b/inotify_simple/inotify_simple.py
@@ -153,6 +153,9 @@ class INotify(object):
         """Close the inotify file descriptor"""
         os.close(self.fd)
 
+    def fileno(self):
+        return self.fd
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
This is a [standard method][1] for file-like objects in Python.  This
allows users to use `INotify` objects with [`select.select`][2].

[1]: https://docs.python.org/3/library/io.html#io.IOBase.fileno
[2]: https://docs.python.org/3/library/select.html#select.select