### PR TITLE
INotify: Make `.close()` idempotent

### DIFF
--- a/inotify_simple/inotify_simple.py
+++ b/inotify_simple/inotify_simple.py
@@ -151,7 +151,9 @@ class INotify(object):
 
     def close(self):
         """Close the inotify file descriptor"""
-        os.close(self.fd)
+        if self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This is much like file objects in the standard library.  With this patch
users will be less likely to close unrelated file-descriptors accidentally.
It also enables use like:

    with INotify("my-file") as inotify:
        ...
        if close_early:
            inotify.close()
        ...

The [python docs][1] say:

> `close()` ... This method has no effect if the file is already closed.

[1]: https://docs.python.org/3.8/library/io.html#io.IOBase.close