### PR TITLE
Fix blocked read bug

### DIFF
--- a/inotify_simple.py
+++ b/inotify_simple.py
@@ -149,8 +149,9 @@ class INotify(FileIO):
     def _readall(self):
         bytes_avail = c_int()
         ioctl(self, FIONREAD, bytes_avail)
-        if bytes_avail.value:
-            return read(self.fileno(), bytes_avail.value)
+        if not bytes_avail.value:
+            return b''
+        return read(self.fileno(), bytes_avail.value)
 
 
 def parse_events(data):

--- a/inotify_simple.py
+++ b/inotify_simple.py
@@ -149,7 +149,8 @@ class INotify(FileIO):
     def _readall(self):
         bytes_avail = c_int()
         ioctl(self, FIONREAD, bytes_avail)
-        return read(self.fileno(), bytes_avail.value)
+        if bytes_avail.value:
+            return read(self.fileno(), bytes_avail.value)
 
 
 def parse_events(data):


### PR DESCRIPTION
This fixes the following use case for me, on Linux Mint 19.3, Python 3.8.1.

Run a script with contents:

```python
#!/usr/bin/env python

import sys
import inotify_simple

inotify = inotify_simple.INotify()
inotify.add_watch(sys.argv[0], inotify_simple.masks.ALL_EVENTS)

while True:
    print(inotify.read())
    print(inotify.read(timeout=100, read_delay=100))
```

Then `touch` the script.

Result:

```python
$ ./repro.py 
Traceback (most recent call last):
  File "./repro.py", line 10, in <module>
    print(inotify.read())
  File "/home/dahl/.pyenv/versions/3.8.1/lib/python3.8/site-packages/inotify_simple.py", line 142, in read
    data = self._readall()
  File "/home/dahl/.pyenv/versions/3.8.1/lib/python3.8/site-packages/inotify_simple.py", line 153, in _readall
    return read(self.fileno(), bytes_avail.value)
OSError: [Errno 22] Invalid argument
```

The appears to be because `posix.read()` does not like `n=0` for max number of bytes to read.
