### PR TITLE
libinotify-kqueue support

### DIFF
--- a/inotify_simple.py
+++ b/inotify_simple.py
@@ -82,7 +82,7 @@ class INotify(FileIO):
                 manually with ``os.read(fd)``) to raise ``BlockingIOError`` if no data
                 is available."""
         try:
-            libc_so = find_library('c')
+            libc_so = find_library('inotify') or find_library('c')
         except RuntimeError: # Python on Synology NASs raises a RuntimeError
             libc_so = None
         global _libc; _libc = _libc or CDLL(libc_so or 'libc.so.6', use_errno=True)


### PR DESCRIPTION
libinotify.so is unlikely to exist on non-BSDs, so let's use `find_library` which is probably lighter than calling `CDLL` twice (one to check if libc.so contains `inotify_init1` then retry with libinotify.so).

Test output:
```
$ python3.9 example.py
Event(wd=1, mask=1073742080, cookie=0, name='foo')
    flags.CREATE
    flags.ISDIR
```
**EDIT:** Not usable as only the first event seems to be reported.