### PR TITLE
inotify_simple: gracefully exit the read on closing (fix #30)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,6 +8,7 @@ from inotify_simple import __version__
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
 ]
 
 master_doc = 'index'
@@ -20,6 +21,10 @@ autodoc_member_order = 'bysource'
 autoclass_content = 'both'
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+}
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme


### PR DESCRIPTION
To be able to unblock the poll.poll() function, a pipe is used and is
registered in the same poll. So when closing, a single write to the pipe
is able to unblock the polling.