### PR TITLE
Fix readthedocs URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Python >= 3.2.
 
 [View on PyPI](http://pypi.python.org/pypi/inotify_simple) |
 [Fork me on github](https://github.com/chrisjbillington/inotify_simple) |
-[Read the docs](http://inotify_simple.readthedocs.org)
+[Read the docs](http://inotify-simple.readthedocs.org)
 
 ## Project status: stable
 
@@ -117,4 +117,4 @@ which events are coming through, but performance critical code should
 generally bitwise-AND masks with flags of interest itself so as to not do
 unnecessary checks.
 
-[See here](http://inotify_simple.readthedocs.org) for more.
+[See here](http://inotify-simple.readthedocs.org) for more.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,7 +26,7 @@ Python >= 3.2.
 
 `View on PyPI <http://pypi.python.org/pypi/inotify_simple>`_
 | `Fork me on GitHub <https://github.com/chrisjbillington/inotify_simple>`_
-| `Read the docs <http://inotify_simple.readthedocs.org>`_
+| `Read the docs <http://inotify-simple.readthedocs.org>`_
 
 ------------
 Installation


### PR DESCRIPTION
While reading the README, I noticed that when visiting the URL http://inotify_simple.readthedocs.org one gets a `Bad Request (400)` error.  I made a guess that the underscore would might be a hyphen on the readthedocs site and it turned out I was right.  This commit fixes the issue and thus allows readers of the docs and the README to find the readthedocs page successfully.