### PR TITLE
Thread-safe read(), pytest tests, and improvements to the behavior of close()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/*
 *.egg-info
 doc/build/*
 doc/fullsource.py
+Dockerfile
+.idea/
+.python-version

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -93,6 +93,13 @@ def raises_ebadfd():
 
 
 @contextmanager
+def raises_einval():
+    with pytest.raises(OSError) as exc_info:
+        yield
+    assert exc_info.value.errno == errno.EINVAL
+
+
+@contextmanager
 def raises_not_open_for_writing():
     # Exception type changed between Python 2 and 3.
     etype = ValueError if PY2 else UnsupportedOperation

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,91 @@
+import errno
+import shutil
+from contextlib import contextmanager
+from tempfile import mkdtemp
+
+import pytest
+
+from inotify_simple import Event, INotify, flags, monotonic
+
+# Equivalent of tempfile.TemporaryDirectory for python 2 support:
+@contextmanager
+def tempdir():
+    rv = mkdtemp()
+    try:
+        yield rv
+    finally:
+        shutil.rmtree(rv)
+
+
+# HACK: estimate and validate the time it takes to do short things (read a ready event or poll then give up), multiply
+# that by 4, and return that value in milliseconds. For use in tests that want a short timeout (to keep tests quick)
+# but not a zero timeout so as not to accidentally only test zero cases.
+def short_timeout(_cache=[]):
+    if _cache:
+        return _cache[0]
+    times = []
+    with tempdir() as tmpdir:
+        watcher = INotify()
+        watcher.add_watch(tmpdir, flags.CREATE)
+        t0 = monotonic()
+        assert watcher.read(timeout=0) == []
+        times.append(monotonic() - t0)
+
+    with tempdir() as tmpdir:
+        watcher = INotify()
+        watcher.add_watch(tmpdir, flags.CREATE)
+        open(tmpdir + '/foo', 'w').write('')
+        t0 = monotonic()
+        assert len(watcher.read(timeout=0)) > 0
+        times.append(monotonic() - t0)
+
+    calibrated_timeout = round(max(times) * 5 * 1000)
+    _cache.append(max(calibrated_timeout, 10))
+    return _cache[0]
+
+
+def assert_events_match(events, count, **kwargs):
+    keys = set(kwargs.keys())
+    assert keys.issubset(Event._fields), "Invalid kwargs {}; should be a subset of {}".format(keys, Event._fields)
+
+    def matches(event):
+        return all(getattr(event, k) == v for k, v in kwargs.items())
+
+    matching = list(filter(matches, events))
+    if count is None or (count > 0 and len(matching) == 0):
+        assert len(matching), "No events matched the predicate {}: {}".format(kwargs, events)
+    else:
+        assert len(matching) == count, "Expected {} events to match the predicate {}, but {} matched: {}".format(count, kwargs, len(matching), events)
+
+@contextmanager
+def raises_ebadfd():
+    # Checking for multiple exception types since they changed between python 2 and 3.
+    with pytest.raises((OSError, IOError)) as exc_info:
+        yield
+    assert exc_info.value.errno == errno.EBADF
+
+@contextmanager
+def assert_takes_between(min_time, max_time=float('inf')):
+    t0 = monotonic()
+    yield
+    duration = monotonic() - t0
+    assert max_time >= duration >= min_time, "Expected duration of {} is not between {} and {}".format(
+        duration,
+        round(min_time, 3),
+        round(max_time, 3),
+    )
+
+
+@contextmanager
+def watcher_and_dir(f, **kwargs):
+    try:
+        with tempdir() as tmpdir:
+            watcher = INotify(**kwargs)
+            watcher.add_watch(tmpdir, f)
+            yield watcher, tmpdir
+    finally:
+        try:
+            watcher.close()
+        except (OSError, IOError) as ex:
+            if 'Bad file descriptor' not in str(ex):
+                raise

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ import pytest
 
 from inotify_simple import Event, INotify, flags, monotonic
 
+
 # Equivalent of tempfile.TemporaryDirectory for python 2 support:
 @contextmanager
 def tempdir():
@@ -34,7 +35,7 @@ def short_timeout(_cache=[]):
     with tempdir() as tmpdir:
         watcher = INotify()
         watcher.add_watch(tmpdir, flags.CREATE)
-        open(tmpdir + '/foo', 'w').write('')
+        open(tmpdir + "/foo", "w").write("")
         t0 = monotonic()
         assert len(watcher.read(timeout=0)) > 0
         times.append(monotonic() - t0)
@@ -46,16 +47,25 @@ def short_timeout(_cache=[]):
 
 def assert_events_match(events, count, **kwargs):
     keys = set(kwargs.keys())
-    assert keys.issubset(Event._fields), "Invalid kwargs {}; should be a subset of {}".format(keys, Event._fields)
+    assert keys.issubset(
+        Event._fields
+    ), "Invalid kwargs {}; should be a subset of {}".format(keys, Event._fields)
 
     def matches(event):
         return all(getattr(event, k) == v for k, v in kwargs.items())
 
     matching = list(filter(matches, events))
     if count is None or (count > 0 and len(matching) == 0):
-        assert len(matching), "No events matched the predicate {}: {}".format(kwargs, events)
+        assert len(matching), "No events matched the predicate {}: {}".format(
+            kwargs, events
+        )
     else:
-        assert len(matching) == count, "Expected {} events to match the predicate {}, but {} matched: {}".format(count, kwargs, len(matching), events)
+        assert (
+            len(matching) == count
+        ), "Expected {} events to match the predicate {}, but {} matched: {}".format(
+            count, kwargs, len(matching), events
+        )
+
 
 @contextmanager
 def raises_ebadfd():
@@ -64,12 +74,15 @@ def raises_ebadfd():
         yield
     assert exc_info.value.errno == errno.EBADF
 
+
 @contextmanager
-def assert_takes_between(min_time, max_time=float('inf')):
+def assert_takes_between(min_time, max_time=float("inf")):
     t0 = monotonic()
     yield
     duration = monotonic() - t0
-    assert max_time >= duration >= min_time, "Expected duration of {} is not between {} and {}".format(
+    assert (
+        max_time >= duration >= min_time
+    ), "Expected duration of {} is not between {} and {}".format(
         duration,
         round(min_time, 3),
         round(max_time, 3),
@@ -87,5 +100,5 @@ def watcher_and_dir(f, **kwargs):
         try:
             watcher.close()
         except (OSError, IOError) as ex:
-            if 'Bad file descriptor' not in str(ex):
+            if "Bad file descriptor" not in str(ex):
                 raise

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1,0 +1,103 @@
+import os
+
+from inotify_simple import INotify, flags
+import pytest
+from tests import (
+    assert_events_match,
+    watcher_and_dir,
+    short_timeout,
+    raises_ebadfd,
+    raises_not_open_for_writing,
+)
+
+
+@pytest.mark.parametrize("read_before_close", (True, False))
+def test_close(read_before_close):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tempdir):
+        assert not watcher.closed
+        assert watcher.fileno() is not None
+
+        if read_before_close:
+            open(tempdir + "/foo", "w").write("")
+            assert_events_match(
+                watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+            )
+
+        for _ in range(3):  # Make sure close is idempotent
+            watcher.close()
+            assert watcher.closed
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            watcher.fileno()
+
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            watcher.add_watch(tempdir, flags.CREATE)
+
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            assert watcher.read(timeout=short_timeout()) == []
+
+
+@pytest.mark.parametrize("raw_close", (True, False))
+def test_closed_descriptor_errors(raw_close):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tempdir):
+        fileno = watcher.fileno()
+        os.fstat(fileno)
+        if raw_close:
+            os.close(fileno)
+        else:
+            watcher.close()
+        with raises_ebadfd():
+            os.fstat(fileno)
+
+        # Make sure the error codes from write change after close:
+        if raw_close:
+            assert watcher.fileno() is not None
+            with raises_ebadfd():
+                watcher.read(timeout=0)
+
+        else:
+            with pytest.raises(ValueError, match="I/O operation on closed file"):
+                watcher.fileno()
+            with raises_ebadfd():
+                os.read(fileno, 1)
+            with pytest.raises(ValueError, match="I/O operation on closed file"):
+                watcher.read(timeout=0)
+
+
+def test_write_errors():
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tempdir):
+        fileno = watcher.fileno()
+        with raises_ebadfd():
+            os.write(fileno, b"a")
+        with raises_not_open_for_writing():
+            watcher.write(b"a")
+        open(tempdir + "/foo", "w").write("")
+        assert_events_match(
+            watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+        )
+        with raises_ebadfd():
+            os.write(fileno, b"a")
+        with raises_not_open_for_writing():
+            watcher.write(b"a")
+
+
+def _get_watcher_fileno(**kwargs):
+    watcher = INotify(**kwargs)
+    return watcher.fileno()
+
+
+def test_autoclose():
+    fileno = _get_watcher_fileno()
+    with raises_ebadfd():
+        os.close(fileno)
+
+    fileno = _get_watcher_fileno(closefd=False)
+    os.close(fileno)
+
+    watcher = INotify(closefd=False)
+    fileno = watcher.fileno()
+    watcher.close()
+    with pytest.raises(ValueError, match="I/O operation on closed file"):
+        watcher.fileno()
+    watcher.close()
+    os.close(fileno)
+    watcher.close()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+from inotify_simple import flags
+from tests import watcher_and_dir, assert_events_match, short_timeout, assert_takes_between, raises_ebadfd
+from threading import Timer
+
+# NB these tests may flake. That is somewhat the cost of doing business: the point of these tests is to validate
+# timings in the presence of concurrency and indeterminate load conditions. If flakes cause problems here, consider:
+# 1. Using a retry loop (manually or via e.g. 'pytest-retry').
+# 2. Increasing INTERVAL_SECONDS and/or SLOP_SECONDS.
+# 3. Skipping the test or falling back to run it manually.
+SLOP_SECONDS = 0.1
+INTERVAL_SECONDS = 0.2
+
+
+@pytest.mark.parametrize('timeout', (None, (INTERVAL_SECONDS + SLOP_SECONDS) * 1000))
+def test_wakeup(timeout):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        timer = Timer(INTERVAL_SECONDS, lambda: open(tmpdir + '/foo', 'w').write(''))
+        try:
+            timer.start()
+            assert_events_match(watcher.read(timeout=timeout), 1, mask=flags.CREATE, name='foo')
+        finally:
+            timer.cancel()
+
+
+@pytest.mark.parametrize('raw_close', (True, False))
+@pytest.mark.parametrize('read_first', (None, 'success', 'fail'))
+def test_close_while_waiting(read_first, raw_close):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        if read_first == 'success':
+            open(tmpdir + '/foo', 'w').write('')
+            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='foo')
+        if read_first == 'fail':
+            assert watcher.read(timeout=short_timeout()) == []
+
+
+        if raw_close:
+            func = lambda: os.close(watcher.fileno())
+            cmgr = raises_ebadfd()
+        else:
+            func = watcher.close
+            cmgr = pytest.raises(ValueError, match='I/O operation on closed file')
+        timer = Timer(INTERVAL_SECONDS, func)
+        try:
+            timer.start()
+            with cmgr, assert_takes_between(INTERVAL_SECONDS - SLOP_SECONDS, INTERVAL_SECONDS + SLOP_SECONDS):
+                watcher.read(timeout=1000)
+        finally:
+            timer.cancel()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,7 +3,13 @@ import os
 import pytest
 
 from inotify_simple import flags
-from tests import watcher_and_dir, assert_events_match, short_timeout, assert_takes_between, raises_ebadfd
+from tests import (
+    watcher_and_dir,
+    assert_events_match,
+    short_timeout,
+    assert_takes_between,
+    raises_ebadfd,
+)
 from threading import Timer
 
 # NB these tests may flake. That is somewhat the cost of doing business: the point of these tests is to validate
@@ -15,38 +21,43 @@ SLOP_SECONDS = 0.1
 INTERVAL_SECONDS = 0.2
 
 
-@pytest.mark.parametrize('timeout', (None, (INTERVAL_SECONDS + SLOP_SECONDS) * 1000))
+@pytest.mark.parametrize("timeout", (None, (INTERVAL_SECONDS + SLOP_SECONDS) * 1000))
 def test_wakeup(timeout):
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
-        timer = Timer(INTERVAL_SECONDS, lambda: open(tmpdir + '/foo', 'w').write(''))
+        timer = Timer(INTERVAL_SECONDS, lambda: open(tmpdir + "/foo", "w").write(""))
         try:
             timer.start()
-            assert_events_match(watcher.read(timeout=timeout), 1, mask=flags.CREATE, name='foo')
+            assert_events_match(
+                watcher.read(timeout=timeout), 1, mask=flags.CREATE, name="foo"
+            )
         finally:
             timer.cancel()
 
 
-@pytest.mark.parametrize('raw_close', (True, False))
-@pytest.mark.parametrize('read_first', (None, 'success', 'fail'))
+@pytest.mark.parametrize("raw_close", (True, False))
+@pytest.mark.parametrize("read_first", (None, "success", "fail"))
 def test_close_while_waiting(read_first, raw_close):
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
-        if read_first == 'success':
-            open(tmpdir + '/foo', 'w').write('')
-            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='foo')
-        if read_first == 'fail':
+        if read_first == "success":
+            open(tmpdir + "/foo", "w").write("")
+            assert_events_match(
+                watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+            )
+        if read_first == "fail":
             assert watcher.read(timeout=short_timeout()) == []
-
 
         if raw_close:
             func = lambda: os.close(watcher.fileno())
             cmgr = raises_ebadfd()
         else:
             func = watcher.close
-            cmgr = pytest.raises(ValueError, match='I/O operation on closed file')
+            cmgr = pytest.raises(ValueError, match="I/O operation on closed file")
         timer = Timer(INTERVAL_SECONDS, func)
         try:
             timer.start()
-            with cmgr, assert_takes_between(INTERVAL_SECONDS - SLOP_SECONDS, INTERVAL_SECONDS + SLOP_SECONDS):
+            with cmgr, assert_takes_between(
+                INTERVAL_SECONDS - SLOP_SECONDS, INTERVAL_SECONDS + SLOP_SECONDS
+            ):
                 watcher.read(timeout=1000)
         finally:
             timer.cancel()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,0 +1,137 @@
+import os
+from io import UnsupportedOperation
+
+from inotify_simple import INotify, flags, PY2
+import pytest
+from tests import assert_events_match, assert_takes_between, watcher_and_dir, short_timeout, raises_ebadfd
+
+CLOSED_FILE_EXCEPTION_TYPE = ValueError if PY2 else UnsupportedOperation
+
+@pytest.mark.parametrize('oneshot', (True, False))
+@pytest.mark.parametrize('check_empty_first', (True, False))
+def test_create(check_empty_first, oneshot):
+    f = flags.CREATE
+    if oneshot:
+        f |= flags.ONESHOT
+    with watcher_and_dir(f) as (watcher, tmpdir):
+        if check_empty_first:
+            assert watcher.read(timeout=short_timeout()) == []
+        open(tmpdir + '/foo', 'w').write('')
+        assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE,  name='foo')
+        open(tmpdir + '/bar', 'w').write('')
+        if oneshot:
+            assert watcher.read(timeout=short_timeout()) == []
+        else:
+            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='bar')
+        assert watcher.read(timeout=short_timeout()) == []
+
+
+@pytest.mark.parametrize('zero_first', (True, False))
+def test_zero_and_nonzero_timeouts(zero_first):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        for _ in range(3):
+            if zero_first:
+                assert watcher.read(timeout=short_timeout()) == []
+            with assert_takes_between(0.15):
+                assert watcher.read(timeout=150) == []
+            if not zero_first:
+                assert watcher.read(timeout=short_timeout()) == []
+
+@pytest.mark.parametrize('first_timeout', (None, 0, 10))
+@pytest.mark.parametrize('second_timeout', (None, 0, 10))
+@pytest.mark.parametrize('check_empty_first', (True, False))
+def test_mixed_timeouts(check_empty_first, first_timeout, second_timeout):
+    with watcher_and_dir(flags.CREATE) as (watcher, tmpdir):
+        if check_empty_first:
+            assert watcher.read(timeout=short_timeout()) == []
+        open(tmpdir + '/foo', 'w').flush()
+        assert_events_match(watcher.read(timeout=first_timeout), 1, mask=flags.CREATE, name='foo')
+        open(tmpdir + '/bar', 'w').flush()
+        assert_events_match(watcher.read(timeout=second_timeout), 1, mask=flags.CREATE, name='bar')
+        assert watcher.read(timeout=short_timeout()) == []
+
+
+@pytest.mark.parametrize('read_before_close', (True, False))
+def test_close(read_before_close):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        assert not watcher.closed
+        assert watcher.fileno() is not None
+
+        if read_before_close:
+            open(tmpdir + '/foo', 'w').write('')
+            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='foo')
+
+        for _ in range(3):  # Make sure close is idempotent
+            watcher.close()
+            assert watcher.closed
+        with pytest.raises(ValueError, match='I/O operation on closed file'):
+            watcher.fileno()
+
+        with pytest.raises(ValueError, match='I/O operation on closed file'):
+            watcher.add_watch(tmpdir, flags.CREATE)
+
+        with pytest.raises(ValueError, match='I/O operation on closed file'):
+            assert watcher.read(timeout=short_timeout()) == []
+
+
+@pytest.mark.parametrize('raw_close', (True, False))
+def test_closed_descriptor_errors(raw_close):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        fileno = watcher.fileno()
+        os.fstat(fileno)
+        if raw_close:
+            os.close(fileno)
+        else:
+            watcher.close()
+        with raises_ebadfd():
+            os.fstat(fileno)
+
+        # Make sure the error codes from write change after close:
+        if raw_close:
+            assert watcher.fileno() is not None
+            with raises_ebadfd():
+                watcher.read(timeout=0)
+
+        else:
+            with pytest.raises(ValueError, match='I/O operation on closed file'):
+                watcher.fileno()
+            with raises_ebadfd():
+                os.read(fileno, 1)
+            with pytest.raises(ValueError, match='I/O operation on closed file'):
+                watcher.read(timeout=0)
+
+
+def test_write_errors():
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+        fileno = watcher.fileno()
+        with raises_ebadfd():
+            os.write(fileno, b'a')
+        with pytest.raises(CLOSED_FILE_EXCEPTION_TYPE, match='File not open for writing'):
+            watcher.write(b'a')
+        open(tmpdir + '/foo', 'w').write('')
+        assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE,  name='foo')
+        with raises_ebadfd():
+            os.write(fileno, b'a')
+        with pytest.raises(CLOSED_FILE_EXCEPTION_TYPE, match='File not open for writing'):
+            watcher.write(b'a')
+
+def _get_watcher_fileno(**kwargs):
+    watcher = INotify(**kwargs)
+    return watcher.fileno()
+
+def test_autoclose():
+    fileno = _get_watcher_fileno()
+    with raises_ebadfd():
+        os.close(fileno)
+
+    fileno = _get_watcher_fileno(closefd=False)
+    os.close(fileno)
+
+    watcher = INotify(closefd=False)
+    fileno = watcher.fileno()
+    watcher.close()
+    with pytest.raises(ValueError, match='I/O operation on closed file'):
+        watcher.fileno()
+    watcher.close()
+    os.close(fileno)
+    watcher.close()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -3,12 +3,19 @@ from io import UnsupportedOperation
 
 from inotify_simple import INotify, flags, PY2
 import pytest
-from tests import assert_events_match, assert_takes_between, watcher_and_dir, short_timeout, raises_ebadfd
+from tests import (
+    assert_events_match,
+    assert_takes_between,
+    watcher_and_dir,
+    short_timeout,
+    raises_ebadfd,
+)
 
 CLOSED_FILE_EXCEPTION_TYPE = ValueError if PY2 else UnsupportedOperation
 
-@pytest.mark.parametrize('oneshot', (True, False))
-@pytest.mark.parametrize('check_empty_first', (True, False))
+
+@pytest.mark.parametrize("oneshot", (True, False))
+@pytest.mark.parametrize("check_empty_first", (True, False))
 def test_create(check_empty_first, oneshot):
     f = flags.CREATE
     if oneshot:
@@ -16,17 +23,21 @@ def test_create(check_empty_first, oneshot):
     with watcher_and_dir(f) as (watcher, tmpdir):
         if check_empty_first:
             assert watcher.read(timeout=short_timeout()) == []
-        open(tmpdir + '/foo', 'w').write('')
-        assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE,  name='foo')
-        open(tmpdir + '/bar', 'w').write('')
+        open(tmpdir + "/foo", "w").write("")
+        assert_events_match(
+            watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+        )
+        open(tmpdir + "/bar", "w").write("")
         if oneshot:
             assert watcher.read(timeout=short_timeout()) == []
         else:
-            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='bar')
+            assert_events_match(
+                watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="bar"
+            )
         assert watcher.read(timeout=short_timeout()) == []
 
 
-@pytest.mark.parametrize('zero_first', (True, False))
+@pytest.mark.parametrize("zero_first", (True, False))
 def test_zero_and_nonzero_timeouts(zero_first):
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
         for _ in range(3):
@@ -37,44 +48,51 @@ def test_zero_and_nonzero_timeouts(zero_first):
             if not zero_first:
                 assert watcher.read(timeout=short_timeout()) == []
 
-@pytest.mark.parametrize('first_timeout', (None, 0, 10))
-@pytest.mark.parametrize('second_timeout', (None, 0, 10))
-@pytest.mark.parametrize('check_empty_first', (True, False))
+
+@pytest.mark.parametrize("first_timeout", (None, 0, 10))
+@pytest.mark.parametrize("second_timeout", (None, 0, 10))
+@pytest.mark.parametrize("check_empty_first", (True, False))
 def test_mixed_timeouts(check_empty_first, first_timeout, second_timeout):
     with watcher_and_dir(flags.CREATE) as (watcher, tmpdir):
         if check_empty_first:
             assert watcher.read(timeout=short_timeout()) == []
-        open(tmpdir + '/foo', 'w').flush()
-        assert_events_match(watcher.read(timeout=first_timeout), 1, mask=flags.CREATE, name='foo')
-        open(tmpdir + '/bar', 'w').flush()
-        assert_events_match(watcher.read(timeout=second_timeout), 1, mask=flags.CREATE, name='bar')
+        open(tmpdir + "/foo", "w").flush()
+        assert_events_match(
+            watcher.read(timeout=first_timeout), 1, mask=flags.CREATE, name="foo"
+        )
+        open(tmpdir + "/bar", "w").flush()
+        assert_events_match(
+            watcher.read(timeout=second_timeout), 1, mask=flags.CREATE, name="bar"
+        )
         assert watcher.read(timeout=short_timeout()) == []
 
 
-@pytest.mark.parametrize('read_before_close', (True, False))
+@pytest.mark.parametrize("read_before_close", (True, False))
 def test_close(read_before_close):
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
         assert not watcher.closed
         assert watcher.fileno() is not None
 
         if read_before_close:
-            open(tmpdir + '/foo', 'w').write('')
-            assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name='foo')
+            open(tmpdir + "/foo", "w").write("")
+            assert_events_match(
+                watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+            )
 
         for _ in range(3):  # Make sure close is idempotent
             watcher.close()
             assert watcher.closed
-        with pytest.raises(ValueError, match='I/O operation on closed file'):
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
             watcher.fileno()
 
-        with pytest.raises(ValueError, match='I/O operation on closed file'):
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
             watcher.add_watch(tmpdir, flags.CREATE)
 
-        with pytest.raises(ValueError, match='I/O operation on closed file'):
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
             assert watcher.read(timeout=short_timeout()) == []
 
 
-@pytest.mark.parametrize('raw_close', (True, False))
+@pytest.mark.parametrize("raw_close", (True, False))
 def test_closed_descriptor_errors(raw_close):
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
         fileno = watcher.fileno()
@@ -93,11 +111,11 @@ def test_closed_descriptor_errors(raw_close):
                 watcher.read(timeout=0)
 
         else:
-            with pytest.raises(ValueError, match='I/O operation on closed file'):
+            with pytest.raises(ValueError, match="I/O operation on closed file"):
                 watcher.fileno()
             with raises_ebadfd():
                 os.read(fileno, 1)
-            with pytest.raises(ValueError, match='I/O operation on closed file'):
+            with pytest.raises(ValueError, match="I/O operation on closed file"):
                 watcher.read(timeout=0)
 
 
@@ -105,19 +123,27 @@ def test_write_errors():
     with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
         fileno = watcher.fileno()
         with raises_ebadfd():
-            os.write(fileno, b'a')
-        with pytest.raises(CLOSED_FILE_EXCEPTION_TYPE, match='File not open for writing'):
-            watcher.write(b'a')
-        open(tmpdir + '/foo', 'w').write('')
-        assert_events_match(watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE,  name='foo')
+            os.write(fileno, b"a")
+        with pytest.raises(
+            CLOSED_FILE_EXCEPTION_TYPE, match="File not open for writing"
+        ):
+            watcher.write(b"a")
+        open(tmpdir + "/foo", "w").write("")
+        assert_events_match(
+            watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+        )
         with raises_ebadfd():
-            os.write(fileno, b'a')
-        with pytest.raises(CLOSED_FILE_EXCEPTION_TYPE, match='File not open for writing'):
-            watcher.write(b'a')
+            os.write(fileno, b"a")
+        with pytest.raises(
+            CLOSED_FILE_EXCEPTION_TYPE, match="File not open for writing"
+        ):
+            watcher.write(b"a")
+
 
 def _get_watcher_fileno(**kwargs):
     watcher = INotify(**kwargs)
     return watcher.fileno()
+
 
 def test_autoclose():
     fileno = _get_watcher_fileno()
@@ -130,7 +156,7 @@ def test_autoclose():
     watcher = INotify(closefd=False)
     fileno = watcher.fileno()
     watcher.close()
-    with pytest.raises(ValueError, match='I/O operation on closed file'):
+    with pytest.raises(ValueError, match="I/O operation on closed file"):
         watcher.fileno()
     watcher.close()
     os.close(fileno)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,17 +1,12 @@
-import os
-from io import UnsupportedOperation
-
-from inotify_simple import INotify, flags, PY2
 import pytest
+
+from inotify_simple import flags
 from tests import (
     assert_events_match,
     assert_takes_between,
     watcher_and_dir,
     short_timeout,
-    raises_ebadfd,
 )
-
-CLOSED_FILE_EXCEPTION_TYPE = ValueError if PY2 else UnsupportedOperation
 
 
 @pytest.mark.parametrize("oneshot", (True, False))
@@ -20,14 +15,14 @@ def test_create(check_empty_first, oneshot):
     f = flags.CREATE
     if oneshot:
         f |= flags.ONESHOT
-    with watcher_and_dir(f) as (watcher, tmpdir):
+    with watcher_and_dir(f) as (watcher, tempdir):
         if check_empty_first:
             assert watcher.read(timeout=short_timeout()) == []
-        open(tmpdir + "/foo", "w").write("")
+        open(tempdir + "/foo", "w").write("")
         assert_events_match(
             watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
         )
-        open(tmpdir + "/bar", "w").write("")
+        open(tempdir + "/bar", "w").write("")
         if oneshot:
             assert watcher.read(timeout=short_timeout()) == []
         else:
@@ -39,7 +34,7 @@ def test_create(check_empty_first, oneshot):
 
 @pytest.mark.parametrize("zero_first", (True, False))
 def test_zero_and_nonzero_timeouts(zero_first):
-    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
+    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tempdir):
         for _ in range(3):
             if zero_first:
                 assert watcher.read(timeout=short_timeout()) == []
@@ -53,111 +48,35 @@ def test_zero_and_nonzero_timeouts(zero_first):
 @pytest.mark.parametrize("second_timeout", (None, 0, 10))
 @pytest.mark.parametrize("check_empty_first", (True, False))
 def test_mixed_timeouts(check_empty_first, first_timeout, second_timeout):
-    with watcher_and_dir(flags.CREATE) as (watcher, tmpdir):
+    with watcher_and_dir(flags.CREATE) as (watcher, tempdir):
         if check_empty_first:
             assert watcher.read(timeout=short_timeout()) == []
-        open(tmpdir + "/foo", "w").flush()
+        open(tempdir + "/foo", "w").flush()
         assert_events_match(
             watcher.read(timeout=first_timeout), 1, mask=flags.CREATE, name="foo"
         )
-        open(tmpdir + "/bar", "w").flush()
+        open(tempdir + "/bar", "w").flush()
         assert_events_match(
             watcher.read(timeout=second_timeout), 1, mask=flags.CREATE, name="bar"
         )
         assert watcher.read(timeout=short_timeout()) == []
 
 
-@pytest.mark.parametrize("read_before_close", (True, False))
-def test_close(read_before_close):
-    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
-        assert not watcher.closed
-        assert watcher.fileno() is not None
-
-        if read_before_close:
-            open(tmpdir + "/foo", "w").write("")
-            assert_events_match(
-                watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
-            )
-
-        for _ in range(3):  # Make sure close is idempotent
-            watcher.close()
-            assert watcher.closed
-        with pytest.raises(ValueError, match="I/O operation on closed file"):
-            watcher.fileno()
-
-        with pytest.raises(ValueError, match="I/O operation on closed file"):
-            watcher.add_watch(tmpdir, flags.CREATE)
-
-        with pytest.raises(ValueError, match="I/O operation on closed file"):
-            assert watcher.read(timeout=short_timeout()) == []
-
-
-@pytest.mark.parametrize("raw_close", (True, False))
-def test_closed_descriptor_errors(raw_close):
-    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
-        fileno = watcher.fileno()
-        os.fstat(fileno)
-        if raw_close:
-            os.close(fileno)
-        else:
-            watcher.close()
-        with raises_ebadfd():
-            os.fstat(fileno)
-
-        # Make sure the error codes from write change after close:
-        if raw_close:
-            assert watcher.fileno() is not None
-            with raises_ebadfd():
-                watcher.read(timeout=0)
-
-        else:
-            with pytest.raises(ValueError, match="I/O operation on closed file"):
-                watcher.fileno()
-            with raises_ebadfd():
-                os.read(fileno, 1)
-            with pytest.raises(ValueError, match="I/O operation on closed file"):
-                watcher.read(timeout=0)
-
-
-def test_write_errors():
-    with watcher_and_dir(flags.CREATE | flags.ONESHOT) as (watcher, tmpdir):
-        fileno = watcher.fileno()
-        with raises_ebadfd():
-            os.write(fileno, b"a")
-        with pytest.raises(
-            CLOSED_FILE_EXCEPTION_TYPE, match="File not open for writing"
-        ):
-            watcher.write(b"a")
-        open(tmpdir + "/foo", "w").write("")
+def test_rm_watch():
+    with watcher_and_dir(flags.CREATE) as (watcher, tempdir):
+        wd = watcher.add_watch(tempdir, flags.CREATE)
+        watcher.rm_watch(wd)
+        open(tempdir + "/foo", "w").flush()
         assert_events_match(
-            watcher.read(timeout=short_timeout()), 1, mask=flags.CREATE, name="foo"
+            watcher.read(timeout=short_timeout()), 1, mask=flags.IGNORED, name=""
         )
-        with raises_ebadfd():
-            os.write(fileno, b"a")
-        with pytest.raises(
-            CLOSED_FILE_EXCEPTION_TYPE, match="File not open for writing"
-        ):
-            watcher.write(b"a")
-
-
-def _get_watcher_fileno(**kwargs):
-    watcher = INotify(**kwargs)
-    return watcher.fileno()
-
-
-def test_autoclose():
-    fileno = _get_watcher_fileno()
-    with raises_ebadfd():
-        os.close(fileno)
-
-    fileno = _get_watcher_fileno(closefd=False)
-    os.close(fileno)
-
-    watcher = INotify(closefd=False)
-    fileno = watcher.fileno()
-    watcher.close()
-    with pytest.raises(ValueError, match="I/O operation on closed file"):
-        watcher.fileno()
-    watcher.close()
-    os.close(fileno)
-    watcher.close()
+        with pytest.raises(OSError, match="Invalid argument"):
+            watcher.rm_watch(wd)
+    with watcher_and_dir(flags.CREATE) as (watcher, tempdir):
+        wd = watcher.add_watch(tempdir, flags.CREATE)
+        watcher.rm_watch(wd)
+        with pytest.raises(OSError, match="Invalid argument"):
+            watcher.rm_watch(wd)
+        assert_events_match(
+            watcher.read(timeout=short_timeout()), 1, mask=flags.IGNORED, name=""
+        )


### PR DESCRIPTION
This PR contains a few miscellaneous improvements; I'm happy to break it up into separate PRs if that's undesirable.

Contents:
1. Attempt to make `read()` thread-safe (as in, it will not unexpectedly block forever or return WOULDBLOCK when called concurrently from multiple threads). 
    - This was accomplished by adding a lock object to INotify instances, tracking the timeout against the time spent waiting for the lock in `read()`. 
2. Add some `pytest` tests for basic functionality of this module. I didn't try to cover everything, just code I touched in this PR, nor did I try to automate the execution of the tests in any way. I was able to run the tests successfully on Pythons 2.7 through 3.12 in Docker with the  below Dockerfile (changing the base image according to what Python version I wanted to test against) and the command `docker build -t test . && docker run -it test pytest -xsqvv`.
3. Support FileIO's `closefd` flag so that this module can be used without closing the underlying file descriptor on `INotify` object destruction. This will be useful for me for e.g. integration with event loops.
4. Improved support for `inheritable=False`. Previously, non-inheritable INotify instances  were only closed on `exec()`; now they're closed on `fork()` on supported Pythons.
5. Moved the instantiation of the `poll()` object to be lazy inside `read()`. This allows expanded use of this module in situations where `poll()` is not functional (i.e. people who just want `parse_event` and the raw FD). 


Open questions in my mind:
- Should this be separate PRs?
- Should `sleep(read_delay)` remain under the lock? In my initial draft, other readers will wait if one reader is sleeping for coalescence.  It wouldn't be too hard to do the sleep outside the lock, but I'm not sure if that would be fair in cases where `read_delay` is greater than timeout: sleeping readers might wait for the extra time and then get no events afterwards.
- Should I run the same code-formatting pass that I ran on the test code against the non-test code that is touched in this PR? That's harmless but expands the amount of diff.

Dockerfile for testing:

```
FROM python:3.12

RUN mkdir -p pymodule
WORKDIR pymodule
RUN pip install pytest
COPY . .
RUN pip install -e .
```