### PR TITLE
Improve support for fsencode, fsdecode, and path object detection, and allow rm_watch to take a path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/*
 *.egg-info
 doc/build/*
 doc/fullsource.py
+Dockerfile
+.idea/
+.python-version

--- a/example.py
+++ b/example.py
@@ -29,3 +29,13 @@ for event in inotify.read():
     print(event)
     for flag in flags.from_mask(event.mask):
         print('    ' + str(flag))
+
+os.mkdir('/tmp/inotify_test2')
+os.mkdir('/tmp/inotify_test3')
+wd = inotify.add_watch('/tmp/inotify_test2', watch_flags)
+inotify.add_watch('/tmp/inotify_test3', watch_flags)
+# Stop watching for events on a watch descriptor without removing the directory:
+inotify.rm_watch(wd)
+
+# Stop watching for events on a path:
+inotify.rm_watch('/tmp/inotify_test3')

--- a/inotify_simple.py
+++ b/inotify_simple.py
@@ -134,7 +134,8 @@ class INotify(FileIO):
         Args:
             wd_or_path (int or PathLike): The watch descriptor number or path to remove."""
         if not isinstance(wd_or_path, int):
-            wd_or_path = self._watches.get(_normalize_path(wd_or_path), -1)
+            # -1 causes the same OSError that would occur if e.g. removing a watch twice:
+            wd_or_path = self._watches.pop(_normalize_path(wd_or_path), -1)
 
         _libc_call(_libc.inotify_rm_watch, self.fileno(), wd_or_path)
 

--- a/inotify_simple.py
+++ b/inotify_simple.py
@@ -1,4 +1,4 @@
-from sys import version_info, getfilesystemencoding
+from sys import version_info, maxsize
 import os
 from enum import Enum, IntEnum
 from collections import namedtuple
@@ -12,13 +12,31 @@ from termios import FIONREAD
 from fcntl import ioctl
 from io import FileIO
 
-PY2 = version_info.major < 3
-if PY2:
-    fsencode = lambda s: s if isinstance(s, str) else s.encode(getfilesystemencoding())
+try:
+    from os import fsencode, fsdecode
+except ImportError:
+    from backports.os import fsencode, fsdecode
+
+if version_info.major < 3 and maxsize < 2**32:
     # In 32-bit Python < 3 the inotify constants don't fit in an IntEnum:
     IntEnum = type('IntEnum', (long, Enum), {})
-else:
-    from os import fsencode, fsdecode
+
+
+try:
+    # Didn't exist before Python 3.6
+    from os import PathLike as _PathClass
+except ImportError:
+    try:
+        # Didn't exist before Python 3.4
+        from pathlib import Path as _PathClass
+    except ImportError:
+        # Doesn't exist in this python, so nothing will pass isinstance:
+        _PathClass = type('_PathClass', (), {})
+
+
+def _normalize_path(path):
+    # Explicit conversion of Path to str required on Python < 3.6
+    return fsencode(str(path) if isinstance(path, _PathClass) else path)
 
 
 __version__ = '1.3.5'
@@ -91,6 +109,7 @@ class INotify(FileIO):
         FileIO.__init__(self, _libc_call(_libc.inotify_init1, flags), mode='rb')
         self._poller = poll()
         self._poller.register(self.fileno())
+        self._watches = dict()
 
     def add_watch(self, path, mask):
         """Wrapper around ``inotify_add_watch()``. Returns the watch
@@ -100,21 +119,24 @@ class INotify(FileIO):
             path (str, bytes, or PathLike): The path to watch. Will be encoded with
                 ``os.fsencode()`` before being passed to ``inotify_add_watch()``.
 
-            mask (int): The mask of events to watch for. Can be constructed by
-                bitwise-ORing :class:`~inotify_simple.flags` together.
+            mask (int (or long on Python 2)): The mask of events to watch for. Can be
+                constructed by bitwise-ORing :class:`~inotify_simple.flags` together.
 
         Returns:
             int: watch descriptor"""
-        # Explicit conversion of Path to str required on Python < 3.6
-        path = str(path) if hasattr(path, 'parts') else path
-        return _libc_call(_libc.inotify_add_watch, self.fileno(), fsencode(path), mask)
+        path = _normalize_path(path)
+        self._watches[path] = rv = _libc_call(_libc.inotify_add_watch, self.fileno(), path, mask)
+        return rv
 
-    def rm_watch(self, wd):
+    def rm_watch(self, wd_or_path):
         """Wrapper around ``inotify_rm_watch()``. Raises ``OSError`` on failure.
 
         Args:
-            wd (int): The watch descriptor to remove"""
-        _libc_call(_libc.inotify_rm_watch, self.fileno(), wd)
+            wd_or_path (int or PathLike): The watch descriptor number or path to remove."""
+        if not isinstance(wd_or_path, int):
+            wd_or_path = self._watches.get(_normalize_path(wd_or_path), -1)
+
+        _libc_call(_libc.inotify_rm_watch, self.fileno(), wd_or_path)
 
     def read(self, timeout=None, read_delay=None):
         """Read the inotify file descriptor and return the resulting
@@ -158,6 +180,13 @@ class INotify(FileIO):
             return b''
         return os.read(self.fileno(), bytes_avail.value)
 
+    def close(self):
+        try:
+            return super(INotify, self).close()
+        finally:
+            # If close is called during __del__ the _watches field may have already been destructed:
+            getattr(self, '_watches', []).clear()
+
 
 def parse_events(data):
     """Unpack data read from an inotify file descriptor into 
@@ -176,7 +205,7 @@ def parse_events(data):
         wd, mask, cookie, namesize = unpack_from(_EVENT_FMT, data, pos)
         pos += _EVENT_SIZE + namesize
         name = data[pos - namesize : pos].split(b'\x00', 1)[0]
-        events.append(Event(wd, mask, cookie, name if PY2 else fsdecode(name)))
+        events.append(Event(wd, mask, cookie, fsdecode(name)))
     return events
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     url='https://github.com/chrisjbillington/inotify_simple',
     license="BSD",
     py_modules=["inotify_simple"],
-    install_requires=["enum34; python_version < '3.4'"],
+    install_requires=[
+        "enum34; python_version < '3.4'",
+        "backports.os; python_version < '3.2'",
+    ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*",
 )


### PR DESCRIPTION
Four changes in this PR:
1. Allow `rm_watch` to take a PathLike or a descriptor number. `add_watch` now tracks created watches internally, and `rm_watch` uses and updates that tracker. `close()` clears the tracker out, which will help with the rare (but pertinent for me) case in which many hundreds of paths have been watched, taking up memory (and not being garbage collected right away since I use the raw inotify fd in asyncio, keeping the object around in a global deliberately-leaked pool even after it's closed; the other PR I submitted will help provide ways around that).
2. On older pythons, use the `fsencode` and `fsdecode` functionality in `backports.os`, which handles really nasty filesystem names better than the current implementations. `backports.os` is pure python, has no transitives, and only implements those two functions, so it's not pulling in a bunch of extra stuff.
3. Be a bit more pedantic about detecting PathLikes. Rather than probing `parts`, this code probes for `os.PathLike` and `pathlib.Path` directly.  This helps deal with custom/weird path objects that may exist in the future. Hey, I said it was pedantic :)
4. Update a docstring to clarify the presence of `long` support on Python 2.

Open questions:
1. Should I probe for `pathlib2.Path` as well? It's the most popular pathlib backport (measured by stars/grep). Not proposing adding pathlib2 to `install_requires`, but I could try-import it and add it to the `isinstance` check.
